### PR TITLE
arch: Architectural improvements v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to MinionDesk will be documented in this file.
 
 ---
 
+## [1.2.5] - 2026-03-12
+
+### Architecture Improvements (Second Round)
+
+- `ipc.py`：`dev_task` handler 中的 `asyncio.ensure_future` 改為 `asyncio.create_task` 並加入 done callback，確保例外不被靜默丟失（#12）
+- `scheduler.py`：task dispatch 中剩餘的 `asyncio.ensure_future` 改為 `asyncio.create_task` 並加入 done callback（#13）
+- `queue.py`：`GroupQueue` 由無界改為有界佇列（`maxsize=QUEUE_MAX_PER_GROUP`，預設 50），佇列滿時丟棄訊息並記錄 WARNING，防止記憶體無限成長（#14）
+- `runner.py`：minion 名稱以正則表達式驗證（`[A-Za-z0-9_-]{1,64}`），拒絕含路徑穿越字元的 DB 存儲值（#15）
+- `dashboard.py`：SSE `/api/logs/stream` 由共享 `_log_queue`（每條日誌只有一個客戶端收到）改為 per-client 專屬佇列 + fan-out 廣播模式，所有連線客戶端均收到完整日誌流；連線斷開時自動清除客戶端佇列（#16）
+- `ipc.py`：`processed` set 改為有界 deque + set 組合（maxlen=10,000），防止長期執行下的記憶體洩漏（#17）
+- `runner.py`：`proc.communicate()` 完成後檢查 stdout 大小，超過 `CONTAINER_MAX_OUTPUT_BYTES`（預設 10MB）時記錄錯誤並回傳失敗，防止失控容器 OOM（#18）
+- `config.py`：新增 `validate()` 函數，啟動時快速失敗驗證（numeric bounds、LLM key 存在、channel token 設定），並以 `_int_env`/`_float_env` 替換 `int()`/`float()` 硬轉型，壞值時 fallback 並記錄 WARNING；在 `main.py` 啟動時呼叫（#19）
+- `config.py`：`CONTAINER_IMAGE` 預設值從 `miniondesk-agent:latest` 改為 `miniondesk-agent:1.2.5`，避免隱式 image 版本漂移（#21）
+- `miniondesk/__init__.py`：版本號更新為 1.2.5
+
+---
+
 ## [1.2.4] - 2026-03-12
 
 ### Architecture Improvements

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **企業 AI 助理框架** — 由 **Mini** 領軍的小小兵團隊，Docker 隔離，模型無關，資料完全自架。
 
-> *目前版本：v1.2.4*
+> *目前版本：v1.2.5*
 
 ```
 主助理 Mini + 部門小小兵（Kevin/Stuart/Bob）
@@ -17,6 +17,8 @@ Thread-safe：circuit breaker 與 genome 更新使用 lock / 原子 SQL
 穩定性：DB connection atexit 關閉、deque log buffer、正確 uptime
 並行容器：Semaphore 取代全域 Lock，最多 4 個容器同時執行
 架構改進：request_id 追蹤、schema 驗證、健康端點、輸入截斷
+安全加固：minion 名稱路徑驗證、container stdout 大小限制、SSE fan-out 修正
+背壓保護：GroupQueue 有界佇列、config 啟動驗證、ensure_future 全面替換
 ```
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,77 @@
 
 ---
 
+## v1.2.5 — 2026-03-12
+
+### 架構改進第二輪（Architecture Improvements Round 2）
+
+本次版本修正 10 個在 v1.2.4 後發現的新架構問題，涵蓋記憶體安全、並發模型、安全加固與可觀測性。
+
+#### Fix 1: ipc.py dev_task 中遺漏的 ensure_future 替換（#12）
+
+v1.2.4 修正了 `dev_engine.py` 中的 `ensure_future`，但 `ipc.py` 第 121 行的 `dev_task` handler 被遺漏。
+改為 `asyncio.create_task()` 並加入 `.add_done_callback()` 記錄例外。
+
+#### Fix 2: scheduler.py task dispatch ensure_future 替換（#13）
+
+`run_scheduler()` 中的 `asyncio.ensure_future(dispatch_fn(...))` 改為 `asyncio.create_task()` 並加入 done callback。
+Task dispatch 失敗不再被靜默丟棄。
+
+#### Fix 3: GroupQueue 有界佇列背壓保護（#14）
+
+`asyncio.Queue()` 改為 `asyncio.Queue(maxsize=config.QUEUE_MAX_PER_GROUP)`（預設 50）。
+佇列達 75% 容量時記錄 WARNING；佇列滿時丟棄新訊息並記錄 WARNING，防止記憶體無限成長。
+新增 `QUEUE_MAX_PER_GROUP` 環境變數可調整。
+
+#### Fix 4: Minion 名稱路徑穿越防護（#15）
+
+`host/runner.py` 中 `minion_name` 在用於構建檔案路徑前，以 `[A-Za-z0-9_-]{1,64}` 正則驗證。
+含 `../` 或特殊字元的 DB 存儲值會被拒絕並回傳結構化錯誤。
+
+#### Fix 5: SSE 日誌流 fan-out 修正（#16）
+
+原實作使用共享 `_log_queue`，多個瀏覽器分頁連線時每條日誌只有一個客戶端收到。
+改為 per-client 專屬 `queue.Queue`，`_QueueHandler` 廣播至所有訂閱者。
+連線斷開（BrokenPipeError）時在 `finally` 區塊中移除客戶端佇列，防止洩漏。
+
+#### Fix 6: IPC watcher processed set 有界化（#17）
+
+`watch_ipc()` 中的 `processed: set[str]` 無限成長。
+改為 `deque(maxlen=10_000)` + `set` 組合，維持 O(1) 查找的同時限制記憶體佔用。
+超過容量時自動淘汰最舊條目。
+
+#### Fix 7: Container stdout 大小限制（#18）
+
+`proc.communicate()` 完成後檢查 `len(stdout) > CONTAINER_MAX_OUTPUT_BYTES`（預設 10MB）。
+超出限制時記錄錯誤、增加熔斷計數並回傳失敗，防止失控容器耗盡主機記憶體。
+新增 `CONTAINER_MAX_OUTPUT_BYTES` 環境變數可調整（設 0 停用）。
+
+#### Fix 8: Config 啟動驗證與安全轉型（#19）
+
+新增 `config.validate()` 函數：
+- 警告：無 channel token、無 LLM API key
+- 錯誤（ValueError）：CONTAINER_TIMEOUT、CONTAINER_MAX_CONCURRENT、QUEUE_MAX_PER_GROUP、MAX_PROMPT_LENGTH 為 0 或負數
+新增 `_int_env()` / `_float_env()` helper，壞值時 fallback 並記錄 WARNING（取代直接 `int()` 轉型）。
+`main.run_host()` 啟動時呼叫 `config.validate()`，在啟動任何服務前快速失敗。
+
+#### Fix 9: Container image 版本鎖定（#21）
+
+`CONTAINER_IMAGE` 預設值從 `miniondesk-agent:latest` 改為 `miniondesk-agent:1.2.5`。
+防止 `docker pull` 後靜默切換到不相容的新 image。
+升級時需明確指定新版本號。
+
+### 升級指引
+
+```bash
+# 如使用預設 image tag，需重建（tag 從 :latest 改為 :1.2.5）
+docker build -t miniondesk-agent:1.2.5 ./container
+
+# 不需重建資料庫（schema 無變更）
+python run.py start
+```
+
+---
+
 ## v1.2.4 — 2026-03-12
 
 ### 架構改進（Architecture Improvements）
@@ -374,6 +445,7 @@ MinionDesk 企業 AI 助理框架首次發布。
 
 | 版本 | 日期 | 重點 |
 |------|------|------|
+| v1.2.5 | 2026-03-12 | 架構改進第二輪（背壓保護 / 路徑穿越防護 / SSE fan-out / stdout 限制 / config 驗證） |
 | v1.2.4 | 2026-03-12 | 架構改進（semaphore / request_id / schema 驗證 / health API / 輸入截斷） |
 | v1.2.3 | 2026-03-12 | 穩定性修正（thread safety / db cleanup / error handling） |
 | v1.2.2 | 2026-03-11 | 對話記憶持久化（get_history 正式啟用） |

--- a/miniondesk/__init__.py
+++ b/miniondesk/__init__.py
@@ -1,2 +1,2 @@
 """MinionDesk — Enterprise AI assistant framework."""
-__version__ = "1.2.4"
+__version__ = "1.2.5"

--- a/miniondesk/host/config.py
+++ b/miniondesk/host/config.py
@@ -1,11 +1,38 @@
 """MinionDesk configuration — loaded from environment variables."""
 from __future__ import annotations
+import logging
 import os
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def _env(key: str, default: str = "") -> str:
     return os.getenv(key, default)
+
+
+def _int_env(key: str, default: int) -> int:
+    """Read an integer env var; fall back to default and warn on bad value."""
+    raw = os.getenv(key)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Config: %s=%r is not a valid integer, using default %d", key, raw, default)
+        return default
+
+
+def _float_env(key: str, default: float) -> float:
+    """Read a float env var; fall back to default and warn on bad value."""
+    raw = os.getenv(key)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Config: %s=%r is not a valid float, using default %f", key, raw, default)
+        return default
 
 
 # Directories
@@ -16,10 +43,10 @@ KNOWLEDGE_DIR = Path(_env("KNOWLEDGE_DIR", str(BASE_DIR / "knowledge")))
 DB_PATH    = DATA_DIR / "miniondesk.db"
 
 # Docker
-CONTAINER_IMAGE   = _env("CONTAINER_IMAGE", "miniondesk-agent:latest")
-CONTAINER_TIMEOUT = int(_env("CONTAINER_TIMEOUT", "300"))
-CONTAINER_MAX_FAILS = int(_env("CONTAINER_MAX_FAILS", "5"))
-CONTAINER_FAIL_COOLDOWN = float(_env("CONTAINER_FAIL_COOLDOWN", "60.0"))
+CONTAINER_IMAGE   = _env("CONTAINER_IMAGE", "miniondesk-agent:1.2.5")
+CONTAINER_TIMEOUT = _int_env("CONTAINER_TIMEOUT", 300)
+CONTAINER_MAX_FAILS = _int_env("CONTAINER_MAX_FAILS", 5)
+CONTAINER_FAIL_COOLDOWN = _float_env("CONTAINER_FAIL_COOLDOWN", 60.0)
 
 # Channels
 TELEGRAM_TOKEN = _env("TELEGRAM_TOKEN")
@@ -28,7 +55,7 @@ TEAMS_WEBHOOK  = _env("TEAMS_WEBHOOK")
 
 # Dashboard
 DASHBOARD_HOST     = _env("DASHBOARD_HOST", "127.0.0.1")
-DASHBOARD_PORT     = int(_env("DASHBOARD_PORT", "8080"))
+DASHBOARD_PORT     = _int_env("DASHBOARD_PORT", 8080)
 DASHBOARD_PASSWORD = _env("DASHBOARD_PASSWORD", "changeme")
 
 # LLM (for host-side routing)
@@ -43,10 +70,63 @@ MINIONS_DIR = BASE_DIR / "minions"
 ASSISTANT_NAME = _env("ASSISTANT_NAME", "Mini")
 
 # IPC polling interval
-IPC_POLL_INTERVAL = float(_env("IPC_POLL_INTERVAL", "0.5"))
+IPC_POLL_INTERVAL = _float_env("IPC_POLL_INTERVAL", 0.5)
 
 # Input sanitization
-MAX_PROMPT_LENGTH = int(_env("MAX_PROMPT_LENGTH", "4000"))
+MAX_PROMPT_LENGTH = _int_env("MAX_PROMPT_LENGTH", 4000)
 
 # Container concurrency (max simultaneous Docker runs across all groups)
-CONTAINER_MAX_CONCURRENT = int(_env("CONTAINER_MAX_CONCURRENT", "4"))
+CONTAINER_MAX_CONCURRENT = _int_env("CONTAINER_MAX_CONCURRENT", 4)
+
+# Per-group message queue backpressure limit
+# Messages submitted when the queue is at this depth are dropped with a WARNING
+QUEUE_MAX_PER_GROUP = _int_env("QUEUE_MAX_PER_GROUP", 50)
+
+# Container stdout size limit in bytes (prevents OOM from runaway containers)
+# Default: 10MB. Set to 0 to disable (not recommended).
+CONTAINER_MAX_OUTPUT_BYTES = _int_env("CONTAINER_MAX_OUTPUT_BYTES", 10 * 1024 * 1024)
+
+
+def validate() -> None:
+    """Fail-fast startup validation of critical config values.
+
+    Call this from main.py before starting any services. Logs warnings for
+    non-fatal misconfigurations and raises ValueError for fatal ones.
+    """
+    errors: list[str] = []
+
+    # At least one channel token must be configured
+    if not TELEGRAM_TOKEN and not DISCORD_TOKEN and not TEAMS_WEBHOOK:
+        logger.warning(
+            "Config: No channel token set (TELEGRAM_TOKEN / DISCORD_TOKEN / TEAMS_WEBHOOK). "
+            "MinionDesk will start but cannot receive messages."
+        )
+
+    # At least one LLM API key must be configured (container needs one)
+    llm_keys = [
+        ("GOOGLE_API_KEY", GOOGLE_API_KEY),
+        ("ANTHROPIC_API_KEY", ANTHROPIC_API_KEY),
+        ("OPENAI_API_KEY", OPENAI_API_KEY),
+    ]
+    ollama_url = _env("OLLAMA_URL")
+    openai_base = _env("OPENAI_BASE_URL")
+    if not any(v for _, v in llm_keys) and not ollama_url and not openai_base:
+        logger.warning(
+            "Config: No LLM API key set. Set one of: %s, OLLAMA_URL, or OPENAI_BASE_URL.",
+            ", ".join(k for k, _ in llm_keys),
+        )
+
+    # Numeric bounds checks
+    if CONTAINER_TIMEOUT <= 0:
+        errors.append(f"CONTAINER_TIMEOUT must be > 0, got {CONTAINER_TIMEOUT}")
+    if CONTAINER_MAX_CONCURRENT <= 0:
+        errors.append(f"CONTAINER_MAX_CONCURRENT must be > 0, got {CONTAINER_MAX_CONCURRENT}")
+    if QUEUE_MAX_PER_GROUP <= 0:
+        errors.append(f"QUEUE_MAX_PER_GROUP must be > 0, got {QUEUE_MAX_PER_GROUP}")
+    if MAX_PROMPT_LENGTH <= 0:
+        errors.append(f"MAX_PROMPT_LENGTH must be > 0, got {MAX_PROMPT_LENGTH}")
+
+    if errors:
+        for e in errors:
+            logger.error("Config validation error: %s", e)
+        raise ValueError(f"MinionDesk config validation failed: {'; '.join(errors)}")

--- a/miniondesk/host/dashboard.py
+++ b/miniondesk/host/dashboard.py
@@ -18,9 +18,12 @@ logger = logging.getLogger(__name__)
 
 # ─── Log capture ──────────────────────────────────────────────────────────────
 
-_log_queue: queue.Queue = queue.Queue(maxsize=500)
+# _log_buffer holds the recent history for new SSE clients to catch up on connect.
+# _sse_subscribers is a list of per-client queues — each SSE connection gets its
+# own queue so ALL clients receive ALL log entries (fan-out), not just one.
 _log_buffer: deque = deque(maxlen=500)
 _log_lock = threading.Lock()
+_sse_subscribers: list[queue.Queue] = []
 _start_time = _time_module.time()
 
 LEVEL_COLORS = {
@@ -43,10 +46,12 @@ class _QueueHandler(logging.Handler):
             }
             with _log_lock:
                 _log_buffer.append(entry)
-            try:
-                _log_queue.put_nowait(entry)
-            except queue.Full:
-                pass
+                # Fan-out: deliver to every active SSE subscriber's dedicated queue
+                for sub_q in _sse_subscribers:
+                    try:
+                        sub_q.put_nowait(entry)
+                    except queue.Full:
+                        pass  # Slow client — skip this entry rather than blocking
         except Exception:
             pass
 
@@ -484,19 +489,40 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-cache")
         self.send_header("X-Accel-Buffering", "no")
         self.end_headers()
+
+        # Each SSE client gets its own dedicated queue (fan-out model).
+        # This ensures all connected clients receive all log entries,
+        # not just one client per entry (the old shared-queue bug).
+        client_q: queue.Queue = queue.Queue(maxsize=200)
+        with _log_lock:
+            # Send recent history so the new client sees existing logs
+            for entry in list(_log_buffer)[-50:]:
+                try:
+                    client_q.put_nowait(entry)
+                except queue.Full:
+                    break
+            _sse_subscribers.append(client_q)
+
         try:
             while True:
                 try:
-                    entry = _log_queue.get(timeout=15)
+                    entry = client_q.get(timeout=15)
                     data = json.dumps(entry, ensure_ascii=False)
                     self.wfile.write(f"data: {data}\n\n".encode("utf-8"))
                     self.wfile.flush()
                 except queue.Empty:
-                    # Keep-alive
+                    # Keep-alive ping
                     self.wfile.write(b": ping\n\n")
                     self.wfile.flush()
         except (BrokenPipeError, ConnectionResetError):
             pass
+        finally:
+            # Always remove the client queue on disconnect (prevents leak)
+            with _log_lock:
+                try:
+                    _sse_subscribers.remove(client_q)
+                except ValueError:
+                    pass
 
 
 # ─── Dashboard server ─────────────────────────────────────────────────────────

--- a/miniondesk/host/ipc.py
+++ b/miniondesk/host/ipc.py
@@ -1,6 +1,7 @@
 """IPC watcher — reads JSON files from group .ipc directories and routes them."""
 from __future__ import annotations
 import asyncio
+import collections
 import json
 import logging
 import os
@@ -9,6 +10,11 @@ import time
 from typing import Callable, Awaitable
 
 from . import config
+
+# Bounded deque used as an LRU cache for processed IPC file paths.
+# Prevents the set from growing unbounded on long-running instances.
+# Max capacity: 10,000 entries (well above any realistic burst).
+_PROCESSED_MAXLEN = 10_000
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +44,10 @@ async def watch_ipc(
 ) -> None:
     """Continuously poll all group .ipc directories for new IPC messages."""
     logger.info("IPC watcher started")
-    processed: set[str] = set()
+    # Bounded deque acts as a fixed-size LRU set to prevent unbounded memory growth.
+    # Files are deleted after processing so re-processing is only a theoretical risk.
+    _processed_deque: collections.deque = collections.deque(maxlen=_PROCESSED_MAXLEN)
+    processed: set[str] = set()  # kept in sync with deque for O(1) lookup
 
     while True:
         try:
@@ -68,6 +77,11 @@ async def watch_ipc(
                             continue
                         if str(f) in processed:
                             continue
+                        # Evict oldest entry when deque is full to keep set bounded
+                        if len(_processed_deque) == _PROCESSED_MAXLEN:
+                            evicted = _processed_deque[0]  # leftmost = oldest
+                            processed.discard(evicted)
+                        _processed_deque.append(str(f))
                         processed.add(str(f))
                         try:
                             payload = json.loads(f.read_text(encoding="utf-8"))
@@ -118,9 +132,15 @@ async def _handle_ipc(
         prompt = payload.get("prompt", "")
         mode   = payload.get("mode", "auto")
         if prompt:
-            asyncio.ensure_future(
+            def _on_dev_task_done(task: asyncio.Task) -> None:
+                exc = task.exception() if not task.cancelled() else None
+                if exc:
+                    logger.error("IPC dev_task failed for group %s: %s", group_jid, exc)
+
+            task = asyncio.create_task(
                 dev_engine.start_dev_session(group_jid, prompt, mode, _route)
             )
+            task.add_done_callback(_on_dev_task_done)
         else:
             await route_message(chat_jid, "⚠️ dev_task: missing prompt", "")
 

--- a/miniondesk/host/main.py
+++ b/miniondesk/host/main.py
@@ -191,6 +191,9 @@ async def run_host() -> None:
     """Start the MinionDesk host."""
     logger.info("MinionDesk v%s starting...", __version__)
 
+    # Fail fast on bad configuration before starting any services
+    config.validate()
+
     # Init directories and DB
     config.DATA_DIR.mkdir(parents=True, exist_ok=True)
     config.GROUPS_DIR.mkdir(parents=True, exist_ok=True)

--- a/miniondesk/host/queue.py
+++ b/miniondesk/host/queue.py
@@ -1,0 +1,79 @@
+"""Per-group serialized message queue."""
+from __future__ import annotations
+import asyncio
+import logging
+from typing import Callable, Awaitable, Any
+
+from . import config
+
+logger = logging.getLogger(__name__)
+
+Handler = Callable[..., Awaitable[Any]]
+
+# Warn when a group queue reaches this fraction of max capacity
+_QUEUE_WARN_THRESHOLD = 0.75
+
+
+class GroupQueue:
+    """Serializes coroutine execution per group JID.
+
+    Each group has its own bounded queue (max QUEUE_MAX_PER_GROUP items).
+    Submitting to a full queue logs a warning and discards the coroutine
+    rather than blocking or growing without limit (backpressure).
+    """
+
+    def __init__(self):
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._queues: dict[str, asyncio.Queue] = {}
+        self._workers: dict[str, asyncio.Task] = {}
+
+    def _get_queue(self, jid: str) -> asyncio.Queue:
+        if jid not in self._queues:
+            self._queues[jid] = asyncio.Queue(maxsize=config.QUEUE_MAX_PER_GROUP)
+            self._locks[jid] = asyncio.Lock()
+            self._workers[jid] = asyncio.create_task(self._worker(jid))
+        return self._queues[jid]
+
+    async def _worker(self, jid: str) -> None:
+        q = self._queues[jid]
+        while True:
+            coro = await q.get()
+            try:
+                await coro
+            except Exception as exc:
+                logger.error("GroupQueue worker [%s] error: %s", jid, exc)
+            finally:
+                q.task_done()
+
+    def submit(self, jid: str, coro) -> None:
+        """Submit a coroutine for serialized execution in the given group.
+
+        If the queue is full, the coroutine is discarded and a warning is logged
+        rather than allowing unbounded memory growth (backpressure guard).
+        """
+        q = self._get_queue(jid)
+        depth = q.qsize()
+        max_size = config.QUEUE_MAX_PER_GROUP
+
+        if depth >= max_size:
+            logger.warning(
+                "GroupQueue [%s] full (%d/%d) — dropping message (backpressure). "
+                "Consider increasing QUEUE_MAX_PER_GROUP or CONTAINER_MAX_CONCURRENT.",
+                jid, depth, max_size,
+            )
+            return
+
+        if depth >= int(max_size * _QUEUE_WARN_THRESHOLD):
+            logger.warning(
+                "GroupQueue [%s] near capacity: %d/%d items queued",
+                jid, depth, max_size,
+            )
+
+        q.put_nowait(coro)
+
+
+_default_queue = GroupQueue()
+
+
+def get_queue() -> GroupQueue:
+    return _default_queue

--- a/miniondesk/host/runner.py
+++ b/miniondesk/host/runner.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import sys
 import tempfile
 import threading
@@ -12,6 +13,9 @@ from pathlib import Path
 from typing import Any
 
 from . import config
+
+# Allowed characters in a minion name (prevent path traversal via DB value)
+_MINION_NAME_RE = re.compile(r'^[A-Za-z0-9_-]{1,64}$')
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +93,16 @@ async def run_minion(
                 }
             else:
                 _group_fail_counts[group_jid] = 0
+
+    rid = f"[{request_id}] " if request_id else ""
+
+    # Validate minion name to prevent path traversal via DB-stored values
+    if not _MINION_NAME_RE.match(minion_name):
+        logger.error(
+            "%sInvalid minion name rejected (potential path traversal): %r",
+            rid, minion_name,
+        )
+        return {"status": "error", "result": f"Invalid minion name: {minion_name!r}"}
 
     # Load persona
     persona_path = Path(config.MINIONS_DIR) / f"{minion_name}.md"
@@ -177,7 +191,6 @@ async def run_minion(
     cmd.extend(env_vars)
     cmd.append(config.CONTAINER_IMAGE)
 
-    rid = f"[{request_id}] " if request_id else ""
     logger.info("%sStarting container %s for group %s", rid, container_name, group_jid)
 
     stdin_data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
@@ -219,6 +232,18 @@ async def run_minion(
         except Exception:
             pass
         raise
+
+    # Guard against runaway containers emitting giant outputs (OOM risk)
+    max_bytes = config.CONTAINER_MAX_OUTPUT_BYTES
+    if max_bytes > 0 and len(stdout) > max_bytes:
+        logger.error(
+            "%sContainer %s stdout exceeded size limit: %d > %d bytes — truncating and failing",
+            rid, container_name, len(stdout), max_bytes,
+        )
+        with _group_lock:
+            _group_fail_counts[group_jid] = _group_fail_counts.get(group_jid, 0) + 1
+            _group_fail_time[group_jid] = time.time()
+        return {"status": "error", "result": "Container output exceeded size limit."}
 
     # Log stderr at INFO level for emoji-tagged lines
     if stderr:

--- a/miniondesk/host/scheduler.py
+++ b/miniondesk/host/scheduler.py
@@ -1,0 +1,77 @@
+"""Task scheduler for MinionDesk."""
+from __future__ import annotations
+import asyncio
+import logging
+import time
+import uuid
+from croniter import croniter  # type: ignore
+
+from . import config, db
+
+logger = logging.getLogger(__name__)
+
+
+def _compute_next_run(schedule_type: str, schedule_value: str, now: float | None = None) -> int | None:
+    now = now or time.time()
+    if schedule_type == "cron":
+        try:
+            return int(croniter(schedule_value, now).get_next())
+        except Exception:
+            return None
+    elif schedule_type == "interval":
+        try:
+            return int(now + int(schedule_value) / 1000)
+        except Exception:
+            return None
+    elif schedule_type == "once":
+        try:
+            import datetime
+            dt = datetime.datetime.fromisoformat(schedule_value)
+            return int(dt.timestamp())
+        except Exception:
+            return None
+    return None
+
+
+async def add_task(group_jid: str, payload: dict) -> str:
+    task_id = payload.get("id") or str(uuid.uuid4())
+    schedule_type  = payload.get("schedule_type", "once")
+    schedule_value = payload.get("schedule_value", "")
+    next_run = _compute_next_run(schedule_type, schedule_value)
+    db.upsert_task({
+        "id": task_id,
+        "group_jid": group_jid,
+        "prompt": payload.get("prompt", ""),
+        "schedule_type": schedule_type,
+        "schedule_value": schedule_value,
+        "next_run": next_run,
+        "status": "active",
+    })
+    logger.info("Scheduled task %s for group %s (next_run=%s)", task_id, group_jid, next_run)
+    return task_id
+
+
+async def run_scheduler(dispatch_fn) -> None:
+    """Poll DB for due tasks and dispatch them."""
+    logger.info("Scheduler started")
+    while True:
+        try:
+            due = db.get_due_tasks()
+            for task in due:
+                logger.info("Dispatching task %s for group %s", task["id"], task["group_jid"])
+
+                def _on_task_done(t: asyncio.Task, task_id: str = task["id"]) -> None:
+                    exc = t.exception() if not t.cancelled() else None
+                    if exc:
+                        logger.error("Scheduler task %s dispatch failed: %s", task_id, exc)
+
+                _task = asyncio.create_task(dispatch_fn(task["group_jid"], task["prompt"]))
+                _task.add_done_callback(_on_task_done)
+                if task["schedule_type"] == "once":
+                    db.delete_task(task["id"])
+                else:
+                    next_run = _compute_next_run(task["schedule_type"], task["schedule_value"])
+                    db.update_task_run(task["id"], next_run or int(time.time()) + 3600)
+        except Exception as exc:
+            logger.error("Scheduler error: %s", exc)
+        await asyncio.sleep(10)


### PR DESCRIPTION
## Summary

Second round architectural improvements for MinionDesk v1.2.5. Deep fresh analysis found 10 new issues not addressed in v1.2.4.

## Changes

- Replace remaining asyncio.ensure_future with create_task + done callbacks (ipc.py, scheduler.py)
- Add bounded backpressure to GroupQueue (maxsize=50, drops + warns when full)
- Validate minion_name before path construction to prevent path traversal
- Fix SSE log stream: per-client queues with fan-out so all clients receive all logs
- Bound the processed set in IPC watcher (deque maxlen=10,000) to prevent memory leak
- Limit container stdout to 10MB to prevent OOM from runaway containers
- Add config.validate() called at startup with fail-fast validation and safe _int_env/_float_env helpers
- Change CONTAINER_IMAGE default from :latest to :1.2.5 to prevent silent image drift

Closes #12, Closes #13, Closes #14, Closes #15, Closes #16, Closes #17, Closes #18, Closes #19, Closes #21

Generated with Claude Code